### PR TITLE
added ability to set as prototype

### DIFF
--- a/array-without.js
+++ b/array-without.js
@@ -1,16 +1,26 @@
 (function(root) {
   'use strict';
 
-  function arrayWithout(a, w) {
-    a = Array.isArray(a) ? a.slice(0) : [];
-    w = flatten([].slice.call(arguments, 1));
-    for (var i = 0; i < w.length; i++) {
-      var j = a.indexOf(w[i]);
+  function arrayWithout(a) {
+    var arr, args;
+    if (Array.isArray(this)) {
+      arr = this.slice(0);
+      args = [].slice.call(arguments);
+    } else {
+      if (!Array.isArray(a)) {
+        return [];
+      }
+      arr = a.slice(0);
+      args = [].slice.call(arguments, 1);
+    }
+    args = flatten(args);
+    for (var i = 0; i < args.length; i++) {
+      var j = arr.indexOf(args[i]);
       if (j > -1) {
-        a.splice(j,1);
+        arr.splice(j, 1);
       }
     }
-    return a;
+    return arr;
   }
 
   function flatten(a) {

--- a/test/array-without.js
+++ b/test/array-without.js
@@ -4,7 +4,7 @@ var without = require('../array-without');
 test('without', function (t) {
   'use strict';
 
-  t.plan(10);
+  t.plan(16);
 
   t.deepEqual(without(['a','b','c'], 'c'), ['a','b']);
   t.deepEqual(without(['a','b','c'], ['b','c']), ['a']);
@@ -16,4 +16,18 @@ test('without', function (t) {
   t.deepEqual(without(123, 'a'), []);
   t.deepEqual(without({}, 'a'), []);
   t.deepEqual(without([1]), [1]);
+
+  try {
+    Array.prototype.without = without;
+    t.deepEqual(['a','b','c'].without('c'), ['a','b']);
+    t.deepEqual(['a','b','c'].without(['b','c']), ['a']);
+    t.deepEqual(['a','b','c'].without('b','c'), ['a']);
+    t.deepEqual(['a','b','c'].without({}), ['a','b','c']);
+    t.deepEqual([].without('a'), []);
+    t.deepEqual([1].without(), [1]);
+  } finally {
+    if (Array.prototype.without) {
+      delete Array.prototype.without;
+    }
+  }
 });


### PR DESCRIPTION
This allows the function to be set as an `Array` prototype member.

``` javascript
Array.prototype.without = require('array-without');
```

But still retains its original functionality.
